### PR TITLE
replace subst with patsubst to fix ncbi/ncbi-vdb#1

### DIFF
--- a/setup/konfigure.perl
+++ b/setup/konfigure.perl
@@ -448,7 +448,7 @@ foreach my $href (@REQ) {
     my $need_lib = $a{type} =~ /L|D/;
     my $need_itf = ! ($a{type} =~ /D/ || $a{type} =~ /J/);
     my $need_jar = $a{type} =~ /J/;
-    
+
     my ($inc, $lib, $ilib) = ($a{include}, $a{lib}); # file names to check
     $lib = '' unless ($lib);
     $lib = expand($lib);
@@ -923,14 +923,14 @@ EndText
         T($F, '@ echo -n "installing \'$(@F)\'... "');
         T($F, '@ if cp $^ $@ && chmod 644 $@;                         \\');
         T($F, '  then                                                 \\');
-        T($F, '      rm -f $(subst $(VERSION),$(MAJVERS),$@) '
-                      . '$(subst $(VERSION_LIBX),$(LIBX),$@) '
-                      . '$(subst .$(VERSION_LIBX),-static.$(LIBX),$@); \\');
-        T($F, '      ln -s $(@F) $(subst $(VERSION),$(MAJVERS),$@);   \\');
-        T($F, '      ln -s $(subst $(VERSION),$(MAJVERS),$(@F)) '
-                      . '$(subst $(VERSION_LIBX),$(LIBX),$@); \\');
-        T($F, '      ln -s $(subst $(VERSION_LIBX),$(LIBX),$(@F)) ' .
-       '$(INST_LIBDIR)$(BITS)/$(subst .$(VERSION_LIBX),-static.$(LIBX),$(@F));'
+        T($F, '      rm -f $(patsubst %$(VERSION),%$(MAJVERS),$@) '
+                      . '$(patsubst %$(VERSION_LIBX),%$(LIBX),$@) '
+                      . '$(patsubst %.$(VERSION_LIBX),%-static.$(LIBX),$@); \\');
+        T($F, '      ln -s $(@F) $(patsubst %$(VERSION),%$(MAJVERS),$@);   \\');
+        T($F, '      ln -s $(patsubst %$(VERSION),%$(MAJVERS),$(@F)) '
+                      . '$(patsubst %$(VERSION_LIBX),%$(LIBX),$@); \\');
+        T($F, '      ln -s $(patsubst %$(VERSION_LIBX),%$(LIBX),$(@F)) ' .
+       '$(INST_LIBDIR)$(BITS)/$(patsubst %.$(VERSION_LIBX),%-static.$(LIBX),$(@F));'
                                                               . ' \\');
         T($F, '      echo success;                                    \\');
         T($F, '  else                                                 \\');
@@ -944,11 +944,11 @@ EndText
         T($F, '@ echo -n "installing \'$(@F)\'... "');
         T($F, '@ if cp $^ $@ && chmod 755 $@;                         \\');
         T($F, '  then                                                 \\');
-        T($F, '      rm -f $(subst $(VERSION),$(MAJVERS),$@) '
-                      . '$(subst $(VERSION_SHLX),$(SHLX),$@);    \\');
-        T($F, '      ln -s $(@F) $(subst $(VERSION),$(MAJVERS),$@);   \\');
-        T($F, '      ln -s $(subst $(VERSION),$(MAJVERS),$(@F)) '
-                      . '$(subst $(VERSION_SHLX),$(SHLX),$@); \\');
+        T($F, '      rm -f $(patsubst %$(VERSION),%$(MAJVERS),$@) '
+                      . '$(patsubst %$(VERSION_SHLX),%$(SHLX),$@);    \\');
+        T($F, '      ln -s $(@F) $(patsubst %$(VERSION),%$(MAJVERS),$@);   \\');
+        T($F, '      ln -s $(patsubst %$(VERSION),%$(MAJVERS),$(@F)) '
+                      . '$(patsubst %$(VERSION_SHLX),%$(SHLX),$@); \\');
         T($F, '      echo success;                                    \\');
         T($F, '  else                                                 \\');
         T($F, '      echo failure;                                    \\');
@@ -960,11 +960,11 @@ EndText
         T($F, '@ echo -n "installing \'$(@F)\'... "');
         T($F, '@ if cp $^ $@ && chmod 755 $@;                         \\');
         T($F, '  then                                                 \\');
-        T($F, '      rm -f $(subst $(VERSION),$(MAJVERS),$@) '
-                      . '$(subst $(VERSION_EXEX),$(EXEX),$@);     \\');
-        T($F, '      ln -s $(@F) $(subst $(VERSION),$(MAJVERS),$@);   \\');
-        T($F, '      ln -s $(subst $(VERSION),$(MAJVERS),$(@F)) '
-                      . '$(subst $(VERSION_EXEX),$(EXEX),$@); \\');
+        T($F, '      rm -f $(patsubst %$(VERSION),%$(MAJVERS),$@) '
+                      . '$(patsubst %$(VERSION_EXEX),%$(EXEX),$@);     \\');
+        T($F, '      ln -s $(@F) $(patsubst %$(VERSION),%$(MAJVERS),$@);   \\');
+        T($F, '      ln -s $(patsubst %$(VERSION),%$(MAJVERS),$(@F)) '
+                      . '$(patsubst %$(VERSION_EXEX),%$(EXEX),$@); \\');
         T($F, '      echo success;                                    \\');
         T($F, '  else                                                 \\');
         T($F, '      echo failure;                                    \\');
@@ -1029,7 +1029,7 @@ if (! $OPT{'status'} ) {
         my $root = $name . '_ROOT';
 
         print OUT <<EndText;
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <$outdir>$TARGDIR/\</$outdir>
 EndText
@@ -1489,7 +1489,7 @@ EndText
         }
 
         print "By default, \`make install' will install all the files in\n";
-    
+
         if (PACKAGE_TYPE() eq 'B') {
             print "\`$package_default_prefix/bin', ";
         } elsif (PACKAGE_TYPE() eq 'L') {
@@ -1541,7 +1541,7 @@ EndText
             println;
         }
     }
-    
+
     if ($optional) {
         print "Optional Packages:\n";
         foreach my $href (@REQ) {


### PR DESCRIPTION
Using more stringent `patsubst` instead of `subst` fixes my issue (#1), and should probably be safer, since the pattern matching is to replace suffixes for version numbers. 

```text
...
make[1]: Leaving directory `/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/src/ncbi-vdb/libs'
NOTE - internal library libkff cannot be built: It requires 'libmagic' and its development headers.
NOTE - library libkdf5 cannot be built: It requires 'libhdf5' and its development headers.
installing 'libncbi-vdb.a.2.4.5'... success
installing 'libncbi-vdb.so.2.4.5'... success
installing 'libncbi-wvdb.a.2.4.5'... success
installing 'libncbi-wvdb.so.2.4.5'... success
installing 'libncbi-ngs-c++.a.2.4.5'... success
Installing includes to /mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/include
Installing configuration files to /mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/lib64/ncbi/
Please add /mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/lib64 to your LD_LIBRARY_PATH, e.g.:
      export LD_LIBRARY_PATH=/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/lib64:$LD_LIBRARY_PATH
Use /mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/lib64 in your link commands, e.g.:
      export NCBI_VDB_LIBDIR=/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/lib64
      ld -L$NCBI_VDB_LIBDIR -lncbi-vdb ...
galaxy@ip-10-63-79-236:/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/src/ncbi-vdb$ cd ..
galaxy@ip-10-63-79-236:/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/src$ cd ..
galaxy@ip-10-63-79-236:/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5$ ls
build  include  INSTALLATION.log  lib64  src
galaxy@ip-10-63-79-236:/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5$ cd lib64/
galaxy@ip-10-63-79-236:/mnt/galaxy/tools/sra_toolkit/2.4.5/matt-shirley/ncbi_sra_toolkit/ef71f5982df5/lib64$ ls
libncbi-ngs-c++.a         libncbi-vdb.a        libncbi-vdb.so.2      libncbi-wvdb.a.2      libncbi-wvdb.so.2.4.5
libncbi-ngs-c++.a.2       libncbi-vdb.a.2      libncbi-vdb.so.2.4.5  libncbi-wvdb.a.2.4.5  libncbi-wvdb-static.a
libncbi-ngs-c++.a.2.4.5   libncbi-vdb.a.2.4.5  libncbi-vdb-static.a  libncbi-wvdb.so       ncbi
libncbi-ngs-c++-static.a  libncbi-vdb.so       libncbi-wvdb.a        libncbi-wvdb.so.2
...
```