### PR TITLE
Fix gcc build error: 'ptrdiff_t' does not name a type

### DIFF
--- a/vdb3/interfaces/memory/MemoryManagerItf.hpp
+++ b/vdb3/interfaces/memory/MemoryManagerItf.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <memory>
+#include <stddef.h>
 
 namespace VDB3
 {


### PR DESCRIPTION
Fix Linux build error seen in Homebrew/Linuxbrew https://github.com/Homebrew/homebrew-core/pull/81521
```
[ 31%] Building CXX object platform/kfc/CMakeFiles/kfc3.dir/zigzag.cpp.o
In file included from /tmp/sratoolkit-20210829-6223-1g4ncrk/sra-tools-2.11.1/ncbi-vdb-source/vdb3/interfaces/memory/MemoryBlockItf.hpp:28:0,
                 from /tmp/sratoolkit-20210829-6223-1g4ncrk/sra-tools-2.11.1/ncbi-vdb-source/vdb3/interfaces/memory/TypedMemoryBlock.hpp:28,
                 from /tmp/sratoolkit-20210829-6223-1g4ncrk/sra-tools-2.11.1/ncbi-vdb-source/vdb3/platform/memory/TypedMemoryBlock.cpp:27:
/tmp/sratoolkit-20210829-6223-1g4ncrk/sra-tools-2.11.1/ncbi-vdb-source/vdb3/interfaces/memory/MemoryManagerItf.hpp:155:13: error: ‘ptrdiff_t’ does not name a type
     typedef ptrdiff_t difference_type;  ///< Difference between two pointers
             ^
```

---

Alternatively, could use `<cstddef>`, but may need to change `ptrdiff_t` to `std::ptrdiff_t`.