### PR TITLE
Recognize pre-release tables

### DIFF
--- a/libs/kdb/kdb-cmn.c
+++ b/libs/kdb/kdb-cmn.c
@@ -752,8 +752,16 @@ static rc_t KDBVGetPathContents_1(KDBContents const **presult, const struct KDir
         if ((bits & scan_col) != 0) {
             // tables only contain columns
             if ((bits & (scan_db | scan_tbl)) == 0) {
-                KDBGetPathContents_Table(result, dir);
-                result->dbtype = kptTable;
+                if ((bits & (scan_meta | scan_md )) == scan_meta
+                 || (bits & (scan_skey | scan_idx)) == scan_skey)
+                {
+                    KDBGetPathContents_GatherColumns(result, dir);
+                    result->dbtype = kptPrereleaseTbl;
+                }
+                else {
+                    KDBGetPathContents_Table(result, dir);
+                    result->dbtype = kptTable;
+                }
             }
         }
         else {


### PR DESCRIPTION
This code is not wrong. As far as KDB is concerned, it is correct. It is the same logic that KDBPathType uses, and KDBPathContents should match KDBPathType. But as far as I can tell, we have no files that are so old that KDBPathType would recognize them as pre-release tables.